### PR TITLE
Feature/response status codes

### DIFF
--- a/src/handlers/base.js
+++ b/src/handlers/base.js
@@ -38,8 +38,7 @@ module.exports = class BaseHandler {
           logger.debug(err)
           return h.redirect(`/error/${err.statusCode}`)
         } else {
-          logger.error(err)
-          return h.view('error500').code(500)
+          throw err
         }
       }
     }

--- a/src/handlers/base.js
+++ b/src/handlers/base.js
@@ -39,7 +39,7 @@ module.exports = class BaseHandler {
           return h.redirect(`/error/${err.statusCode}`)
         } else {
           logger.error(err)
-          return h.view('error500')
+          return h.view('error500').code(500)
         }
       }
     }

--- a/src/lib/authorization-schemes.js
+++ b/src/lib/authorization-schemes.js
@@ -7,7 +7,6 @@
 const Joi = require('joi')
 const Client = require('../api/client')
 const LicenceApi = require('../api/licence')
-const { logger } = require('defra-logging-facade')
 
 // Joi schema to validate a licence payload
 const licenceSchema = Joi.object().keys({
@@ -58,7 +57,7 @@ module.exports = {
           if (Math.floor(Number.parseInt(err.statusCode) / 100) === 4) {
             return h.continue
           } else {
-            return h.redirect('/error500').takeover()
+            throw err
           }
         }
       },
@@ -113,10 +112,8 @@ module.exports = {
         } catch (err) {
           if (Math.floor(Number.parseInt(err.statusCode) / 100) === 4) {
             return h.continue
-          } else {
-            logger.error(err)
-            return h.redirect('/error500').takeover()
           }
+          throw err
         }
       },
 

--- a/src/routes/angler.js
+++ b/src/routes/angler.js
@@ -196,36 +196,5 @@ module.exports = [
     handler: (request, h) => {
       return h.view('privacy')
     }
-  },
-
-  // Error 500 handler
-  {
-    path: '/error500',
-    method: 'GET',
-    options: { auth: false },
-    handler: (request, h) => {
-      return h.view('error500').code(500)
-    }
-  },
-
-  // Error 4xx handler
-  {
-    path: '/error/{status}',
-    method: 'GET',
-    options: { auth: false },
-    handler: (request, h) => {
-      return h.view('error4', { status: request.params.status })
-    }
-  },
-
-  // Catch all
-  {
-    method: '*',
-    path: '/{p*}',
-    options: { auth: false },
-    handler: function (request, h) {
-      return h.redirect('/')
-    }
   }
-
 ]

--- a/src/routes/angler.js
+++ b/src/routes/angler.js
@@ -204,7 +204,7 @@ module.exports = [
     method: 'GET',
     options: { auth: false },
     handler: (request, h) => {
-      return h.view('error500')
+      return h.view('error500').code(500)
     }
   },
 

--- a/src/views/error4.html
+++ b/src/views/error4.html
@@ -5,13 +5,13 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        {% if status === '400' %}
+        {% if status === 400 %}
             <h1 class="govuk-heading-xl">Bad request</h1>
-        {% elseif status === '401' %}
+        {% elseif status === 401 %}
             <h1 class="govuk-heading-xl">Unauthorized</h1>
-        {% elseif status === '403' %}
+        {% elseif status === 403 %}
             <h1 class="govuk-heading-xl">Forbidden</h1>
-        {% elseif status === '404' %}
+        {% elseif status === 404 %}
             <h1 class="govuk-heading-xl">Page not found</h1>
         {% else %}
             <h1 class="govuk-heading-xl">Error</h1>


### PR DESCRIPTION
Required in order to be able to monitor HTTP response status codes at the infrastructure level.  Have tested this through on pre-production and it is giving the expected behaviour.  Need Tom to make a change to the nginx configuration to allow the content of HTTP 500 errors to propograte through to the client.