### PR TITLE
Upload artifacts to S3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('defra-shared@feature/iwtf-2874-s3-interface') _
 def arti = defraArtifactory()
-def s3 = defraS3()
+def s3
 
 pipeline {
     agent any
@@ -9,6 +9,16 @@ pipeline {
             steps {
                 script {
                     BUILD_TAG = buildTag.updateJenkinsJob()
+                    withCredentials([
+                        [
+                            $class: 'AmazonWebServicesCredentialsBinding', 
+                            credentialsId: 'aps-rcr-user',
+                            accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                            secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                        ]
+                    ]) {
+                        s3 = defraS3()
+                    }
                 }
             }
         }
@@ -36,14 +46,12 @@ pipeline {
                 //     }
                 // }
                 script {
-                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aps-rcr-user']]) {
-                        s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
-                        // sh """
-                        //     echo hello > abc.txt 
-                        //     aws s3 cp abc.txt s3://apsldnrcrsrv001
-                        //     aws s3 cp ${DIST_FILE} s3://apsldnrcrsrv001
-                        // """
-                    }
+                    s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                    // sh """
+                    //     echo hello > abc.txt 
+                    //     aws s3 cp abc.txt s3://apsldnrcrsrv001
+                    //     aws s3 cp ${DIST_FILE} s3://apsldnrcrsrv001
+                    // """
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-shared@feature/iwtf-2874-s3-interface') _
+@Library('defra-shared@master') _
 def arti = defraArtifactory()
 def s3
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,11 +37,12 @@ pipeline {
                 // }
                 script {
                     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aps-rcr-user']]) {
-                        sh """
-                            echo hello > abc.txt 
-                            aws s3 cp abc.txt s3://apsldnrcrsrv001
-                            aws s3 cp ${DIST_FILE} s3://apsldnrcrsrv001
-                        """
+                        s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                        // sh """
+                        //     echo hello > abc.txt 
+                        //     aws s3 cp abc.txt s3://apsldnrcrsrv001
+                        //     aws s3 cp ${DIST_FILE} s3://apsldnrcrsrv001
+                        // """
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-shared@master') _
+@Library('defra-shared@feature/iwtf-2874-s3-interface') _
 def arti = defraArtifactory()
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,8 +30,10 @@ pipeline {
         stage('Upload distribution') {
             steps {
                 script {
-                    // arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
-                    s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aps-rcr-user']]) {
+                        // arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                        s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
         stage('Upload distribution') {
             steps {
                 script {
-                    arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                    // arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
                     s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-shared@master') _
+@Library('defra-shared@feature/iwtf-2874-s3-interface') _
 def arti = defraArtifactory()
 def s3
 
@@ -17,7 +17,7 @@ pipeline {
                             secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
                         ]
                     ]) {
-                        s3 = defraS3('apsldnrcrsrv001')
+                        s3 = defraS3()
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,26 +32,15 @@ pipeline {
         stage('Archive distribution') {
             steps {
                 script {
-                    // DIST_FILE = arti.createDistributionFile(env.WORKSPACE, "rcr_web")
                     DIST_FILE = s3.createDistributionFile(env.WORKSPACE, "rcr_web")
                 }
             }
         }
         stage('Upload distribution') {
             steps {
-                // script {
-                //     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aps-rcr-user']]) {
-                //         // arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
-                //         s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
-                //     }
-                // }
                 script {
+                    arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
                     s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
-                    // sh """
-                    //     echo hello > abc.txt 
-                    //     aws s3 cp abc.txt s3://apsldnrcrsrv001
-                    //     aws s3 cp ${DIST_FILE} s3://apsldnrcrsrv001
-                    // """
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
         stage('Upload distribution') {
             steps {
                 script {
-                    // arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                    arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
                     s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 @Library('defra-shared@feature/iwtf-2874-s3-interface') _
 def arti = defraArtifactory()
+def s3 = defraS3()
 
 pipeline {
     agent any
@@ -21,14 +22,16 @@ pipeline {
         stage('Archive distribution') {
             steps {
                 script {
-                    DIST_FILE = arti.createDistributionFile(env.WORKSPACE, "rcr_web")
+                    // DIST_FILE = arti.createDistributionFile(env.WORKSPACE, "rcr_web")
+                    DIST_FILE = s3.createDistributionFile(env.WORKSPACE, "rcr_web")
                 }
             }
         }
         stage('Upload distribution') {
             steps {
                 script {
-                    arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                    // arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                    s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,23 +27,21 @@ pipeline {
                 }
             }
         }
-        node {
-            stage('Upload distribution') {
-                steps {
-                    // script {
-                    //     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aps-rcr-user']]) {
-                    //         // arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
-                    //         s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
-                    //     }
-                    // }
-                    script {
-                        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aps-rcr-user']]) {
-                            sh """
-                                echo hello > abc.txt 
-                                aws s3 cp abc.txt s3://apsldnrcrsrv001
-                                aws s3 cp ${DIST_FILE} s3://apsldnrcrsrv001
-                            """
-                        }
+        stage('Upload distribution') {
+            steps {
+                // script {
+                //     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aps-rcr-user']]) {
+                //         // arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                //         s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                //     }
+                // }
+                script {
+                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aps-rcr-user']]) {
+                        sh """
+                            echo hello > abc.txt 
+                            aws s3 cp abc.txt s3://apsldnrcrsrv001
+                            aws s3 cp ${DIST_FILE} s3://apsldnrcrsrv001
+                        """
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
                             secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
                         ]
                     ]) {
-                        s3 = defraS3()
+                        s3 = defraS3('apsldnrcrsrv001')
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,12 +27,23 @@ pipeline {
                 }
             }
         }
-        stage('Upload distribution') {
-            steps {
-                script {
-                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aps-rcr-user']]) {
-                        // arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
-                        s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+        node {
+            stage('Upload distribution') {
+                steps {
+                    // script {
+                    //     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aps-rcr-user']]) {
+                    //         // arti.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                    //         s3.uploadArtifact("rcr-snapshots/web/", "rcr_web", BUILD_TAG, DIST_FILE)
+                    //     }
+                    // }
+                    script {
+                        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aps-rcr-user']]) {
+                            sh """
+                                echo hello > abc.txt 
+                                aws s3 cp abc.txt s3://apsldnrcrsrv001
+                                aws s3 cp ${DIST_FILE} s3://apsldnrcrsrv001
+                            """
+                        }
                     }
                 }
             }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2874

Beginning the process of replacing Artifactory with S3, we use the new S3 interface to create the distribution file and then upload to S3, keeping Artifactory in place until we can completely switch over to S3.