### PR TITLE
Update Ubuntu version used for GH Actions builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ on:
 jobs:
   tests:
     name: tests
-    runs-on: ubuntu-18.04
-    
+    runs-on: ubuntu-latest
+
     steps:
       - name: Start Redis
         uses: supercharge/redis-github-action@1.1.0


### PR DESCRIPTION
GitHub Actions is deprecating Ubuntu 18.04 for builds so we need to update this.