### PR TITLE
Set Node version for build job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,10 @@ pipeline {
         stage('Build') {
             steps {
                 script {
-                    sh  "npm ci"
+                    sh  """
+                        . /var/lib/jenkins/.bashrc && nvm install v18
+                        npm ci
+                    """
                 }
             }
         }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3902

Since updating some packages we found that the build job was failing on Jenkins. This turned out to be from using the wrong version of Node. This change makes sure that we are building with the desired version.