### PR TITLE
Remove reference to licence card from RCR journey

### DIFF
--- a/src/views/licence.html
+++ b/src/views/licence.html
@@ -50,7 +50,8 @@
 
             {{ govukInput({
                     label: {
-                        text: "Last 6 characters of rod licence number"
+                        text: "Last 6 characters of rod licence number",
+                        classes: "govuk-label--m"
                     },
                     hint: {
                         text: "This can be found on your licence or your catch return reminder. For example, B7A718."
@@ -64,7 +65,8 @@
 
                 {{ govukInput({
                     label: {
-                        text: "Postcode"
+                        text: "Postcode",
+                        classes: "govuk-label--m"
                     },
                     hint: {
                         text: "For example, WA4 8HT."

--- a/src/views/licence.html
+++ b/src/views/licence.html
@@ -50,7 +50,7 @@
 
             {{ govukInput({
                     label: {
-                        text: "Last 6 characters of your licence number"
+                        text: "Last 6 characters of rod licence number"
                     },
                     hint: {
                         text: "This can be found on your licence or your catch return reminder. For example, B7A718."

--- a/src/views/licence.html
+++ b/src/views/licence.html
@@ -53,7 +53,7 @@
                         text: "Last 6 characters of your licence number"
                     },
                     hint: {
-                        text: "Your licence number is printed on any correspondence from us. It also appears on the back of your licence card. For example, B7A718"
+                        text: "This can be found on your licence or your catch return reminder. For example, B7A718."
                     },
                     id: "licence",
                     name: "licence",
@@ -67,7 +67,7 @@
                         text: "Postcode"
                     },
                     hint: {
-                        text: "For example, WA4 8HT"
+                        text: "For example, WA4 8HT."
                     },
                     id: "postcode",
                     name: "postcode",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4090

The first page in the RCR journey refers to a licence card. We need to remove the word "card" from the journey because we will no longer be issuing licence cards from the end of May.

The styling for the field labels is also in need of updating, to make them easier the scan.