### PR TITLE
Pin GitHub Actions to specific SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
       - name: Checkout frontend
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Install node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24.x"
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
           HTTPS: false
         run: npm run test
       - name: SonarCloud Scan
-        uses: sonarSource/sonarqube-scan-action@master
+        uses: sonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           use_embedded_jre: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - master
-      - release/js-api-rewrite
   push:
     branches:
       - master


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-5161

Updated security guidance is to pin Actions to a specific SHA to avoid supply chain attacks on our workflows.