### PR TITLE
Upgrade npm to 11.19.0 and add scripts to allowlist in rod-catch-returns-frontend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24.x"
+      - name: Install npm 11.19.0
+        run: npm install -g npm@11.19.0
       - name: Install dependencies
         run: npm ci
       - name: Run Tests

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+ignore-scripts=true
+min-release-age=7

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -9,7 +9,8 @@ WORKDIR /app
 
 # Install app dependencies
 COPY / /app
-RUN npm install pm2 -g --ignore-scripts \
+RUN npm install -g npm@11.19.0 \
+    && npm install pm2 -g --ignore-scripts \
     && npm install --ignore-scripts
 
 # Default service port

--- a/package.json
+++ b/package.json
@@ -7,7 +7,13 @@
   "author": "Graham Willis, Sam Gardner-Dell",
   "main": "index.js",
   "engines": {
-    "node": ">24.0.0"
+    "node": ">24.0.0",
+    "npm": ">=11.19.0"
+  },
+  "allowScripts": {
+    "es5-ext@0.10.63": true,
+    "preact@8.5.3": true,
+    "unrs-resolver@1.11.1": true
   },
   "scripts": {
     "lint": "eslint 'src/**/*.js'",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-5176

npm upgrade to v11.19.0

• updating the npm version in GitHub Actions

• updating the npm version in Docker

• running npm approve-scripts --allow-scripts-pending to see which dependencies have scripts

• reviewing the affected dependencies to make sure they’re trustworthy

• adding them to the script allowlist in package.json

• adding an .npmrc file with the [department-approved configuration](https://defra.github.io/software-development-standards/standards/node_standards/#npmrc-security-settings)